### PR TITLE
Bump actions setup-java to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up JDK 15
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: adopt
         java-version: 15
 
     - name: Build with Maven

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up JDK 15
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: adopt
         java-version: 15
 
     - name: Build with Maven


### PR DESCRIPTION
Bump actions setup-java from v1 to v2, see https://github.com/actions/setup-java.